### PR TITLE
[fix] Re-order kitchen configs

### DIFF
--- a/run_kitchen_joyent.sh
+++ b/run_kitchen_joyent.sh
@@ -6,7 +6,13 @@ $DIR/set_env.sh
 
 # Force test-kitchen to use config in jenkin's home
 # One config to rule them all
-export KITCHEN_LOCAL_YAML=~jenkins/.kitchen/config_joyent.yml
+# Precedence:
+# 1) KITCHEN_LOCAL_YAML (highest)
+# 2) KITCHEN_YAML
+# 3) KITCHEN_GLOBAL_YAML (lowest)
+export KITCHEN_LOCAL_YAML=$WORKSPACE/repo/.kitchen-override.yml
+export KITCHEN_YAML=~jenkins/.kitchen/config_joyent.yml
+export KITCHEN_GLOBAL_YAML=$WORKSPACE/repo/.kitchen.yml
 
 cd $WORKSPACE/repo
 rvm use 2.2.2


### PR DESCRIPTION
This change re-orders the precedence of the various configurations that we
use for a `kitchen-ci` run.