### PR TITLE
[fix] Add key to SSH agent before connecting

### DIFF
--- a/run_kitchen_joyent.sh
+++ b/run_kitchen_joyent.sh
@@ -1,6 +1,14 @@
 #!/bin/bash --login
 DIR=$(cd $(dirname "$0"); pwd)
 
+# Start the ssh agent. Evaling the output will set the relevant environment
+# variables
+eval `ssh-agent`
+
+# Add the default keys like id_rsa and id_dsa (or explicitly specify your key,
+# if it's not a default)
+ssh-add ~jenkins/.ssh/joyent.pem
+
 # Create environment
 $DIR/set_env.sh
 
@@ -21,3 +29,13 @@ if [ -f Thorfile ]; then
 else
   bundle exec strainer test --only kitchen
 fi
+
+# Save the return value of your script
+RETVAL=$?
+
+# Clean up
+kill $SSH_AGENT_PID
+
+# Exit the script with the true return value instead of the return value of kill
+# which could be successful even when the build has crashed
+exit $RETVAL


### PR DESCRIPTION
In this change, the `ssh-agent` is initialized and the key to connect to the
SDC instance is added. This should fix the issue where `kitchen` tries to
SSH into the new SDC instance and is asked for a password, which fails because
there's no TTY available.