### PR TITLE
Install kitchen-joyent gem

### DIFF
--- a/run_kitchen_joyent.sh
+++ b/run_kitchen_joyent.sh
@@ -24,6 +24,7 @@ export KITCHEN_GLOBAL_YAML=$WORKSPACE/repo/.kitchen.yml
 
 cd $WORKSPACE/repo
 rvm use 2.2.2
+gem install kitchen-joyent
 if [ -f Thorfile ]; then
   bundle exec thor test:kitchen
 else


### PR DESCRIPTION
Instead of relying on whether a cookbook has the `kitchen-joyent` gem in its
`Gemfile`, we could install the gem right away. This will clear out the failed
runs because the `joyent` provider for Kitchen CI could not be found.