### PR TITLE
Fix SSH issues for Joyent and SDC

### DIFF
--- a/run_kitchen_joyent.sh
+++ b/run_kitchen_joyent.sh
@@ -1,14 +1,6 @@
 #!/bin/bash --login
 DIR=$(cd $(dirname "$0"); pwd)
 
-# Start the ssh agent. Evaling the output will set the relevant environment
-# variables
-eval `ssh-agent`
-
-# Add the default keys like id_rsa and id_dsa (or explicitly specify your key,
-# if it's not a default)
-ssh-add ~jenkins/.ssh/joyent.pem
-
 # Create environment
 $DIR/set_env.sh
 
@@ -39,13 +31,3 @@ if [ -f Thorfile ]; then
 else
   bundle exec strainer test --only kitchen
 fi
-
-# Save the return value of your script
-RETVAL=$?
-
-# Clean up
-kill $SSH_AGENT_PID
-
-# Exit the script with the true return value instead of the return value of kill
-# which could be successful even when the build has crashed
-exit $RETVAL

--- a/run_kitchen_sdc.sh
+++ b/run_kitchen_sdc.sh
@@ -1,14 +1,6 @@
 #!/bin/bash --login
 DIR=$(cd $(dirname "$0"); pwd)
 
-# Start the ssh agent. Evaling the output will set the relevant environment
-# variables
-eval `ssh-agent`
-
-# Add the default keys like id_rsa and id_dsa (or explicitly specify your key,
-# if it's not a default)
-ssh-add ~jenkins/.ssh/sdc.pem
-
 # Create environment
 $DIR/set_env.sh
 
@@ -39,13 +31,3 @@ if [ -f Thorfile ]; then
 else
   bundle exec strainer test --only kitchen
 fi
-
-# Save the return value of your script
-RETVAL=$?
-
-# Clean up
-kill $SSH_AGENT_PID
-
-# Exit the script with the true return value instead of the return value of kill
-# which could be successful even when the build has crashed
-exit $RETVAL


### PR DESCRIPTION
`ssh-agent` doesn't seem to work on LX brand zones, so we'll have to go without it. There's a PR for `optoro_jenkins` pending that should include using the correct key for Joyent / SDC kitchen testing.